### PR TITLE
Refactor ODataBatchReader

### DIFF
--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -263,7 +263,7 @@ namespace Microsoft.OData.MultipartMixed
                 }
             }
 
-            requestUri = BuildOperationRequestUri(new Uri(uriSegment, UriKind.RelativeOrAbsolute), this.rawInputContext.MessageReaderSettings.BaseUri);
+            requestUri = new Uri(uriSegment, UriKind.RelativeOrAbsolute);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -180,9 +180,9 @@ namespace Microsoft.OData.MultipartMixed
             // write pending message data (headers, response line) for a previously unclosed message/request
             this.WritePendingMessageData(true);
 
-            // important to do this first since it will set up the change set boundary.
             this.SetState(BatchWriterState.ChangesetStarted);
-            Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
+            Debug.Assert(this.changeSetBoundary == null, "this.changeSetBoundary == null");
+            this.changeSetBoundary = ODataMultipartMixedBatchWriterUtils.CreateChangeSetBoundary(this.rawOutputContext.WritingResponse);
 
             // write the boundary string
             ODataMultipartMixedBatchWriterUtils.WriteStartBoundary(this.rawOutputContext.TextWriter, this.batchBoundary, !this.batchStartBoundaryWritten);
@@ -206,28 +206,11 @@ namespace Microsoft.OData.MultipartMixed
             // write pending message data (headers, response line) for a previously unclosed message/request
             this.WritePendingMessageData(true);
 
-            // Add a potential Content-ID header to the URL resolver so that it will be available
-            // to subsequent operations.
-            // Note that what we add here is the Content-ID header of the previous operation (if any).
-            // This also means that the Content-ID of the last operation in a changeset will never get
-            // added to the cache which is fine since we cannot reference it anywhere.
-            if (this.CurrentOperationContentId != null)
-            {
-                AddToPayloadUriConverter(this.CurrentOperationContentId);
-            }
-
-            this.InterceptException(() => uri = CreateOperationRequestUriWrapper(uri, this.rawOutputContext.MessageWriterSettings.BaseUri));
-
             // create the new request operation
-            this.CurrentOperationRequestMessage = BuildOperationRequestMessage(
+            ODataBatchOperationRequestMessage operationRequestMessage = BuildOperationRequestMessage(
                 this.rawOutputContext.OutputStream,
                 method,
                 uri);
-
-            if (this.changeSetBoundary != null)
-            {
-                this.RememberContentIdHeader(contentId);
-            }
 
             this.SetState(BatchWriterState.OperationCreated);
 
@@ -239,7 +222,7 @@ namespace Microsoft.OData.MultipartMixed
                 this.rawOutputContext.MessageWriterSettings.BaseUri, changeSetBoundary != null, contentId,
                 payloadUriOption);
 
-            return this.CurrentOperationRequestMessage;
+            return operationRequestMessage;
         }
 
         /// <summary>
@@ -276,6 +259,9 @@ namespace Microsoft.OData.MultipartMixed
 
             // change the state first so we validate the change set boundary before attempting to write it.
             this.SetState(BatchWriterState.ChangesetCompleted);
+
+            Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
+            this.changeSetBoundary = null;
 
             // In the case of an empty changeset the start changeset boundary has not been written yet
             // we will leave it like that, since we want the empty changeset to be represented only as
@@ -315,35 +301,6 @@ namespace Microsoft.OData.MultipartMixed
         }
 
         /// <summary>
-        /// Additional processing required when setting a new writer state.
-        /// </summary>
-        /// <param name="newState">The writer state to transition into.</param>
-        protected override void SetStateImplementation(BatchWriterState newState)
-        {
-            // Sets the changeset boundary for changeset boundary changes.
-            switch (newState)
-            {
-                case BatchWriterState.BatchStarted:
-                    Debug.Assert(!this.batchStartBoundaryWritten, "The batch boundary must not be written before calling WriteStartBatch.");
-                    break;
-                case BatchWriterState.ChangesetStarted:
-                    Debug.Assert(this.changeSetBoundary == null, "this.changeSetBoundary == null");
-                    this.changeSetBoundary = ODataMultipartMixedBatchWriterUtils.CreateChangeSetBoundary(this.rawOutputContext.WritingResponse);
-                    break;
-                case BatchWriterState.ChangesetCompleted:
-                    Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
-                    this.changeSetBoundary = null;
-                    break;
-            }
-        }
-
-        protected override void ValidateTransitionImplementation(BatchWriterState newState)
-        {
-            // Additional validation for multipart/mixed batch writer.
-            ValidateTransitionAgainstChangesetBoundary(newState, this.changeSetBoundary);
-        }
-
-        /// <summary>
         /// Verifies that the writer is not disposed.
         /// </summary>
         protected override void VerifyNotDisposed()
@@ -352,35 +309,20 @@ namespace Microsoft.OData.MultipartMixed
         }
 
         /// <summary>
-        /// Writer specific implementation to verify that CreateOperationRequestMessage is valid.
-        /// For Multipart/Mixed writer, this implementation verifies that, for the case within a changeset,
-        /// CreateOperationRequestMessage is valid.
-        /// </summary>
-        /// <param name="method">The HTTP method to be validated.</param>
-        /// <param name="uri">The Uri to be used for this request operation.</param>
-        /// <param name="contentId">The content Id string to be validated.</param>
-        protected override void VerifyCanCreateOperationRequestMessageImplementation(string method, Uri uri, string contentId)
-        {
-            if (this.changeSetBoundary != null)
-            {
-                if (HttpUtils.IsQueryMethod(method))
-                {
-                    this.ThrowODataException(Strings.ODataBatch_InvalidHttpMethodForChangeSetRequest(method));
-                }
-
-                if (string.IsNullOrEmpty(contentId))
-                {
-                    this.ThrowODataException(Strings.ODataBatchOperationHeaderDictionary_KeyNotFound(ODataConstants.ContentIdHeader));
-                }
-            }
-        }
-
-        /// <summary>
         /// Starts a new batch - implementation of the actual functionality.
         /// </summary>
         protected override void WriteStartBatchImplementation()
         {
             this.SetState(BatchWriterState.BatchStarted);
+        }
+
+        /// <summary>
+        /// Whether the writer is currently processing inside a sub-batch.
+        /// </summary>
+        /// <returns>True if the writer processing is inside a changeset.</returns>
+        protected override bool IsInsideSubBatch()
+        {
+            return this.changeSetBoundary != null;
         }
 
         /// <summary>
@@ -466,41 +408,6 @@ namespace Microsoft.OData.MultipartMixed
                     this.CurrentOperationMessage.PartHeaderProcessingCompleted();
                     this.CurrentOperationRequestMessage = null;
                     this.CurrentOperationResponseMessage = null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Validates state transition is allowed if we are within a changeset.
-        /// </summary>
-        /// <param name="newState">Teh new writer state to transition into.</param>
-        /// <param name="changeSetBoundary">The changeset boundary string.</param>
-        private static void ValidateTransitionAgainstChangesetBoundary(BatchWriterState newState, string changeSetBoundary)
-        {
-            // make sure that we are not starting a changeset when one is already active
-            if (newState == BatchWriterState.ChangesetStarted)
-            {
-                if (changeSetBoundary != null)
-                {
-                    throw new ODataException(Strings.ODataBatchWriter_CannotStartChangeSetWithActiveChangeSet);
-                }
-            }
-
-            // make sure that we are not completing a changeset without an active changeset
-            if (newState == BatchWriterState.ChangesetCompleted)
-            {
-                if (changeSetBoundary == null)
-                {
-                    throw new ODataException(Strings.ODataBatchWriter_CannotCompleteChangeSetWithoutActiveChangeSet);
-                }
-            }
-
-            // make sure that we are not completing a batch while a changeset is still active
-            if (newState == BatchWriterState.BatchCompleted)
-            {
-                if (changeSetBoundary != null)
-                {
-                    throw new ODataException(Strings.ODataBatchWriter_CannotCompleteBatchWithActiveChangeSet);
                 }
             }
         }

--- a/src/Microsoft.OData.Core/ODataBatchReader.cs
+++ b/src/Microsoft.OData.Core/ODataBatchReader.cs
@@ -320,7 +320,8 @@ namespace Microsoft.OData
             Uri requestUri,
             ODataBatchOperationHeaders headers)
         {
-            return new ODataBatchOperationRequestMessage(streamCreatorFunc, method, requestUri, headers, this,
+            Uri uri = BuildOperationRequestUri(requestUri, this.inputContext.MessageReaderSettings.BaseUri);
+            return new ODataBatchOperationRequestMessage(streamCreatorFunc, method, uri, headers, this,
                 this.contentIdToAddOnNextRead, this.payloadUriConverter, /*writing*/ false, this.container);
         }
 
@@ -376,6 +377,14 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Reset the URL converter
+        /// </summary>
+        protected void ResetPayloadUriConverter()
+        {
+            this.payloadUriConverter.Reset();
+        }
+
+        /// <summary>
         /// Instantiate an <see cref="Uri"/> object.
         /// </summary>
         /// <param name="requestUri">The uri to process.</param>
@@ -387,17 +396,9 @@ namespace Microsoft.OData
         /// This method will fail if no custom resolution is implemented and the specified <paramref name="requestUri"/> is
         /// relative and there's no base URI available.
         /// </remarks>
-        protected Uri BuildOperationRequestUri(Uri requestUri, Uri baseUri)
+        private Uri BuildOperationRequestUri(Uri requestUri, Uri baseUri)
         {
             return ODataBatchUtils.CreateOperationRequestUri(requestUri, baseUri, this.payloadUriConverter);
-        }
-
-        /// <summary>
-        /// Reset the URL converter
-        /// </summary>
-        protected void ResetPayloadUriConverter()
-        {
-            this.payloadUriConverter.Reset();
         }
 
         /// <summary>

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4034,7 +4034,6 @@ public abstract class Microsoft.OData.ODataBatchReader : IODataBatchOperationLis
 	Microsoft.OData.ODataBatchReaderState State  { public get; }
 
 	protected Microsoft.OData.ODataBatchOperationRequestMessage BuildOperationRequestMessage (System.Func`1[[System.IO.Stream]] streamCreatorFunc, string method, System.Uri requestUri, Microsoft.OData.ODataBatchOperationHeaders headers)
-	protected System.Uri BuildOperationRequestUri (System.Uri requestUri, System.Uri baseUri)
 	protected Microsoft.OData.ODataBatchOperationResponseMessage BuildOperationResponseMessage (System.Func`1[[System.IO.Stream]] streamCreatorFunc, int statusCode, Microsoft.OData.ODataBatchOperationHeaders headers)
 	public Microsoft.OData.ODataBatchOperationRequestMessage CreateOperationRequestMessage ()
 	public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync ()
@@ -4065,7 +4064,6 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataBatchOperationLis
 	Microsoft.OData.ODataBatchOperationRequestMessage CurrentOperationRequestMessage  { protected get; protected set; }
 	Microsoft.OData.ODataBatchOperationResponseMessage CurrentOperationResponseMessage  { protected get; protected set; }
 
-	protected void AddToPayloadUriConverter (string contentId)
 	public abstract void BatchOperationContentStreamDisposed ()
 	public abstract void BatchOperationContentStreamRequested ()
 	public abstract System.Threading.Tasks.Task BatchOperationContentStreamRequestedAsync ()
@@ -4076,7 +4074,6 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataBatchOperationLis
 	public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId)
 	public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption)
 	protected abstract Microsoft.OData.ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption)
-	protected System.Uri CreateOperationRequestUriWrapper (System.Uri uri, System.Uri baseUri)
 	public Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessage (string contentId)
 	public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageAsync (string contentId)
 	protected abstract Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation (string contentId)
@@ -4084,12 +4081,9 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataBatchOperationLis
 	public System.Threading.Tasks.Task FlushAsync ()
 	protected abstract System.Threading.Tasks.Task FlushAsynchronously ()
 	protected abstract void FlushSynchronously ()
+	protected abstract bool IsInsideSubBatch ()
 	public abstract void OnInStreamError ()
-	protected void RememberContentIdHeader (string contentId)
 	protected void SetState (Microsoft.OData.ODataBatchWriter+BatchWriterState newState)
-	protected virtual void SetStateImplementation (Microsoft.OData.ODataBatchWriter+BatchWriterState newState)
-	protected virtual void ValidateTransitionImplementation (Microsoft.OData.ODataBatchWriter+BatchWriterState newState)
-	protected virtual void VerifyCanCreateOperationRequestMessageImplementation (string method, System.Uri uri, string contentId)
 	protected abstract void VerifyNotDisposed ()
 	public void WriteEndBatch ()
 	public System.Threading.Tasks.Task WriteEndBatchAsync ()


### PR DESCRIPTION
ODataBatchReader has some protected members that I think we can (and should) get rid of.  

ContentId Handling
The current handling of ContentId is pretty convoluted, with the contentId being passed back and forth between base class and derived class, and held as a property on the base class until it's used.  I think we can simplify this significantly by having the derived class simply pass the contentId for the current operation in to BuildOperationRequestMessage/BuildOperationResponseMessage; the base class can take care of validation, adding to the PayloadUriConverter, etc.  I don't think we need the contentIdToAddOnNextRead; we can just add it to the PayloadUriConverter when the operation message is created, and we can get rid of VerifyAndSetContentId.

The logic for getting a contentId from a header in RecordContentId is specific to multipart/mixed and should just be in the derived class, and then pass the ContentId when building the operation message, so we should be able to remove RecordContentId.

ResetPayloadUriConverter should really be private logic in the base class, but I understand the logic is currently different due to legacy reasons between the multipart/mixed and JSON batch implementations (multipart/mixed has a uniqueness scope of a changeset, where-as JSON has no such limitations).  Really, though, this isn't so much a format restriction as a version restriction; we have relaxed the constraint in 4.01 that only allowed statements to reference other statements within the same changeset. So I'm thinking we might be able to put this logic in the base class and tie it to the ODataVersion.  Let me play with this a bit…

ChangesetBoundary
ResetReaderStreamChangesetBoundary is called in changesetend, but base class should have no knowledge of changeset boundaries. We should instead make this private logic in the derived class, and just call it from ReadAtChangesetEndImplementation prior to calling SkipToNextPartAndReadHeaders.

VerifyReaderStreamChangesetStartImplementation
Rather than have this a separate protected method called by the base class, this logic should be part of the multipart/mixed implementation of ReadAtChangesetStartImplementation.

GetNextStateOnNewPart
The derived type should determine the next state; you can move the logic from GetNextStateOnNewPart to SkipToNextPartAndReadHeaders in the multipart/mixed type.  The base type should increase changeset or batch size in ReadOperation.  You can add a private flag to the base class isInChangeSet, set it to true in ReadImplementation for ChangeSetStart, and false for ChangeSetEnd, then use that on Operation state to determine whether to increment changeset or batchsize.

ThrowODataException
I haven't seen this pattern in the other readers/writers, but I think it's fine.

