### PR TITLE
Demonstrates clean factoring of multipart/mixed out of non-multipart/…

### DIFF
--- a/src/Microsoft.OData.Core/MediaTypeUtils.cs
+++ b/src/Microsoft.OData.Core/MediaTypeUtils.cs
@@ -190,71 +190,6 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Determine the <see cref="ODataFormat"/> to use for the given <paramref name="contentTypeHeader"/>. If no supported content type
-        /// is found an exception is thrown.
-        /// </summary>
-        /// <param name="contentTypeHeader">The name of the content type to be checked.</param>
-        /// <param name="supportedPayloadKinds">All possiblel kinds of payload that can be read with this content type.</param>
-        /// <param name="mediaTypeResolver">The media type resolver to use when interpreting the content type.</param>
-        /// <param name="mediaType">The media type parsed from the <paramref name="contentTypeHeader"/>.</param>
-        /// <param name="encoding">The encoding from the content type or the default encoding for the <paramref name="mediaType" />.</param>
-        /// <param name="selectedPayloadKind">
-        /// The payload kind that was selected form the list of <paramref name="supportedPayloadKinds"/> for the
-        /// specified <paramref name="contentTypeHeader"/>.
-        /// </param>
-        /// <param name="batchBoundary">The batch boundary read from the content type for batch payloads; otherwise null.</param>
-        /// <returns>The <see cref="ODataFormat"/> for the <paramref name="contentTypeHeader"/>.</returns>
-        internal static ODataFormat GetFormatFromContentType(
-            string contentTypeHeader,
-            ODataPayloadKind[] supportedPayloadKinds,
-            ODataMediaTypeResolver mediaTypeResolver,
-            out ODataMediaType mediaType,
-            out Encoding encoding,
-            out ODataPayloadKind selectedPayloadKind,
-            out string batchBoundary)
-        {
-            Debug.Assert(!supportedPayloadKinds.Contains(ODataPayloadKind.Unsupported), "!supportedPayloadKinds.Contains(ODataPayloadKind.Unsupported)");
-
-            ODataFormat format = GetFormatFromContentType(contentTypeHeader, supportedPayloadKinds, mediaTypeResolver, out mediaType, out encoding, out selectedPayloadKind);
-
-            // for batch payloads, read the batch boundary from the content type header; this is the only
-            // content type parameter we support (and that is required for batch payloads)
-            if (selectedPayloadKind == ODataPayloadKind.Batch)
-            {
-                KeyValuePair<string, string> boundaryPair = default(KeyValuePair<string, string>);
-                IEnumerable<KeyValuePair<string, string>> parameters = mediaType.Parameters;
-                if (parameters != null)
-                {
-                    bool boundaryPairFound = false;
-                    foreach (KeyValuePair<string, string> pair in parameters.Where(p => HttpUtils.CompareMediaTypeParameterNames(ODataConstants.HttpMultipartBoundary, p.Key)))
-                    {
-                        if (boundaryPairFound)
-                        {
-                            throw new ODataException(Strings.MediaTypeUtils_BoundaryMustBeSpecifiedForBatchPayloads(contentTypeHeader, ODataConstants.HttpMultipartBoundary));
-                        }
-
-                        boundaryPair = pair;
-                        boundaryPairFound = true;
-                    }
-                }
-
-                if (boundaryPair.Key == null)
-                {
-                    throw new ODataException(Strings.MediaTypeUtils_BoundaryMustBeSpecifiedForBatchPayloads(contentTypeHeader, ODataConstants.HttpMultipartBoundary));
-                }
-
-                batchBoundary = boundaryPair.Value;
-                ValidationUtils.ValidateBoundaryString(batchBoundary);
-            }
-            else
-            {
-                batchBoundary = null;
-            }
-
-            return format;
-        }
-
-        /// <summary>
         /// Gets all payload kinds and their corresponding formats that match the specified content type header.
         /// </summary>
         /// <param name="contentTypeHeader">The content type header to get the payload kinds for.</param>
@@ -422,7 +357,7 @@ namespace Microsoft.OData
         /// specified <paramref name="contentTypeName"/>.
         /// </param>
         /// <returns>The <see cref="ODataFormat"/> for the <paramref name="contentTypeName"/>.</returns>
-        private static ODataFormat GetFormatFromContentType(string contentTypeName, ODataPayloadKind[] supportedPayloadKinds, ODataMediaTypeResolver mediaTypeResolver, out ODataMediaType mediaType, out Encoding encoding, out ODataPayloadKind selectedPayloadKind)
+        internal static ODataFormat GetFormatFromContentType(string contentTypeName, ODataPayloadKind[] supportedPayloadKinds, ODataMediaTypeResolver mediaTypeResolver, out ODataMediaType mediaType, out Encoding encoding, out ODataPayloadKind selectedPayloadKind)
         {
             Debug.Assert(!supportedPayloadKinds.Contains(ODataPayloadKind.Unsupported), "!supportedPayloadKinds.Contains(ODataPayloadKind.Unsupported)");
 

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -36,23 +36,23 @@ namespace Microsoft.OData.MultipartMixed
         /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
         /// <param name="batchEncoding">The encoding to use to read from the batch stream.</param>
         /// <param name="synchronous">true if the reader is created for synchronous operation; false for asynchronous.</param>
-        internal ODataMultipartMixedBatchReader(ODataRawInputContext inputContext, string batchBoundary, Encoding batchEncoding, bool synchronous)
+        internal ODataMultipartMixedBatchReader(ODataMultipartMixedBatchInputContext inputContext, string batchBoundary, Encoding batchEncoding, bool synchronous)
             : base(inputContext, synchronous)
         {
             Debug.Assert(inputContext != null, "inputContext != null");
             Debug.Assert(!string.IsNullOrEmpty(batchBoundary), "!string.IsNullOrEmpty(batchBoundary)");
 
-            this.batchStream = new ODataMultipartMixedBatchReaderStream(this.RawInputContext, batchBoundary, batchEncoding);
+            this.batchStream = new ODataMultipartMixedBatchReaderStream(this.MultipartMixedBatchInputContext, batchBoundary, batchEncoding);
         }
 
         /// <summary>
         /// Gets the reader's input context as the real runtime type.
         /// </summary>
-        private ODataRawInputContext RawInputContext
+        private ODataMultipartMixedBatchInputContext MultipartMixedBatchInputContext
         {
             get
             {
-                return this.InputContext as ODataRawInputContext;
+                return this.InputContext as ODataMultipartMixedBatchInputContext;
             }
         }
 
@@ -225,7 +225,7 @@ namespace Microsoft.OData.MultipartMixed
         /// <param name="requestUri">The parsed <see cref="Uri"/> of the request.</param>
         private void ParseRequestLine(string requestLine, out string httpMethod, out Uri requestUri)
         {
-            Debug.Assert(!this.RawInputContext.ReadingResponse, "Must only be called for requests.");
+            Debug.Assert(!this.MultipartMixedBatchInputContext.ReadingResponse, "Must only be called for requests.");
 
             // Batch Request: POST /Customers HTTP/1.1
             // Since the uri can contain spaces, the only way to read the request url, is to
@@ -283,7 +283,7 @@ namespace Microsoft.OData.MultipartMixed
         [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "'this' is used when built in debug")]
         private int ParseResponseLine(string responseLine)
         {
-            Debug.Assert(this.RawInputContext.ReadingResponse, "Must only be called for responses.");
+            Debug.Assert(this.MultipartMixedBatchInputContext.ReadingResponse, "Must only be called for responses.");
 
             // Batch Response: HTTP/1.1 200 Ok
             // Since the http status code strings have spaces in them, we cannot use the same

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OData.MultipartMixed
         /// </summary>
         /// <param name="rawOutputContext">The output context to write to.</param>
         /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
-        internal ODataMultipartMixedBatchWriter(ODataRawOutputContext rawOutputContext, string batchBoundary)
+        internal ODataMultipartMixedBatchWriter(ODataMultipartMixedBatchOutputContext rawOutputContext, string batchBoundary)
             : base(rawOutputContext)
         {
             Debug.Assert(rawOutputContext != null, "rawOutputContext != null");
@@ -57,9 +57,9 @@ namespace Microsoft.OData.MultipartMixed
         /// <summary>
         /// Gets the writer's output context as the real runtime type.
         /// </summary>
-        private ODataRawOutputContext RawOutputContext
+        private ODataMultipartMixedBatchOutputContext RawOutputContext
         {
-            get { return this.OutputContext as ODataRawOutputContext; }
+            get { return this.OutputContext as ODataMultipartMixedBatchOutputContext; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataFormat.cs
+++ b/src/Microsoft.OData.Core/ODataFormat.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OData
 #if PORTABLELIB
     using System.Threading.Tasks;
 #endif
+    using System.Text;
     using Microsoft.OData.Json;
     #endregion Namespaces
 
@@ -129,5 +130,17 @@ namespace Microsoft.OData
         /// <returns>Task which represents the pending create operation.</returns>
         public abstract Task<ODataOutputContext> CreateOutputContextAsync(ODataMessageInfo messageInfo, ODataMessageWriterSettings messageWriterSettings);
 #endif
+
+        /// <summary>
+        /// Returns the appropriate content-type for this format.
+        /// </summary>
+        /// <param name="mediaType">The specified media type.</param>
+        /// <param name="encoding">The specified encoding.</param>
+        /// <param name="writingResponse">True if the message writer is being used to write a response.</param>
+        /// <returns>The content-id for the format.</returns>
+        internal virtual string GetContentType(ODataMediaType mediaType, Encoding encoding, bool writingResponse)
+        {
+            return HttpUtils.BuildContentType(mediaType, encoding);
+        }
     }
 }

--- a/src/Microsoft.OData.Core/ODataInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataInputContext.cs
@@ -433,12 +433,11 @@ namespace Microsoft.OData
         /// <summary>
         /// Create a <see cref="ODataBatchReader"/>.
         /// </summary>
-        /// <param name="batchBoundary">The batch boundary to use.</param>
         /// <returns>The newly created <see cref="ODataBatchReader"/>.</returns>
         /// <remarks>
         /// Since we don't want to support batch format extensibility (at least not yet) this method should remain internal.
         /// </remarks>
-        internal virtual ODataBatchReader CreateBatchReader(string batchBoundary)
+        internal virtual ODataBatchReader CreateBatchReader()
         {
             throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.Batch);
         }
@@ -447,12 +446,11 @@ namespace Microsoft.OData
         /// <summary>
         /// Asynchronously create a <see cref="ODataBatchReader"/>.
         /// </summary>
-        /// <param name="batchBoundary">The batch boundary to use.</param>
         /// <returns>Task which when completed returns the newly created <see cref="ODataBatchReader"/>.</returns>
         /// <remarks>
         /// Since we don't want to support batch format extensibility (at least not yet) this method should remain internal.
         /// </remarks>
-        internal virtual Task<ODataBatchReader> CreateBatchReaderAsync(string batchBoundary)
+        internal virtual Task<ODataBatchReader> CreateBatchReaderAsync()
         {
             throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.Batch);
         }

--- a/src/Microsoft.OData.Core/ODataMessageReader.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReader.cs
@@ -77,10 +77,6 @@ namespace Microsoft.OData
         /// <remarks>This field is set implicitly when one of the read (or reader creation) methods is called.</remarks>
         private Encoding encoding;
 
-        /// <summary>The batch boundary string if the payload to be read is a batch request or response.</summary>
-        /// <remarks>This is set implicitly when the CreateBatchReader method is called.</remarks>
-        private string batchBoundary;
-
         /// <summary>The context information for the message.</summary>
         private ODataMessageInfo messageInfo;
 
@@ -520,7 +516,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanCreateODataBatchReader();
             return this.ReadFromInput(
-                (context) => context.CreateBatchReader(this.batchBoundary),
+                (context) => context.CreateBatchReader(),
                 ODataPayloadKind.Batch);
         }
 
@@ -531,7 +527,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanCreateODataBatchReader();
             return this.ReadFromInputAsync(
-                (context) => context.CreateBatchReaderAsync(this.batchBoundary),
+                (context) => context.CreateBatchReaderAsync(),
                 ODataPayloadKind.Batch);
         }
 #endif
@@ -922,7 +918,7 @@ namespace Microsoft.OData
 
             // Set the format, encoding and payload kind.
             string contentTypeHeader = this.GetContentTypeHeader(payloadKinds);
-            this.format = MediaTypeUtils.GetFormatFromContentType(contentTypeHeader, payloadKinds, this.mediaTypeResolver, out this.contentType, out this.encoding, out this.readerPayloadKind, out this.batchBoundary);
+            this.format = MediaTypeUtils.GetFormatFromContentType(contentTypeHeader, payloadKinds, this.mediaTypeResolver, out this.contentType, out this.encoding, out this.readerPayloadKind);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -17,7 +17,6 @@ namespace Microsoft.OData
 #endif
     using Microsoft.OData.Edm;
     using Microsoft.OData.Metadata;
-    using Microsoft.OData.MultipartMixed;
     #endregion Namespaces
 
     /// <summary>
@@ -67,10 +66,6 @@ namespace Microsoft.OData
         /// <summary>The <see cref="Encoding"/> of the payload to be written with this writer.</summary>
         /// <remarks>This is either set via the SetHeadersForPayload method or implicitly when one of the write (or writer creation) methods is called.</remarks>
         private Encoding encoding;
-
-        /// <summary>The batch boundary string if the payload to be written is a batch request or response.</summary>
-        /// <remarks>This is either set via the SetHeadersForPayload method or implicitly when the CreateBatchWriter method is called.</remarks>
-        private string batchBoundary;
 
         /// <summary>Flag to prevent writing more than one error to the payload.</summary>
         private bool writeErrorCalled;
@@ -462,7 +457,7 @@ namespace Microsoft.OData
             this.VerifyCanCreateODataBatchWriter();
             return this.WriteToOutput(
                 ODataPayloadKind.Batch,
-                (context) => context.CreateODataBatchWriter(this.batchBoundary));
+                (context) => context.CreateODataBatchWriter());
         }
 
 #if PORTABLELIB
@@ -473,7 +468,7 @@ namespace Microsoft.OData
             this.VerifyCanCreateODataBatchWriter();
             return this.WriteToOutputAsync(
                 ODataPayloadKind.Batch,
-                (context) => context.CreateODataBatchWriterAsync(this.batchBoundary));
+                (context) => context.CreateODataBatchWriterAsync());
         }
 #endif
 
@@ -816,7 +811,7 @@ namespace Microsoft.OData
             if (!string.IsNullOrEmpty(contentType))
             {
                 ODataPayloadKind computedPayloadKind;
-                this.format = MediaTypeUtils.GetFormatFromContentType(contentType, new ODataPayloadKind[] { this.writerPayloadKind }, this.mediaTypeResolver, out this.mediaType, out this.encoding, out computedPayloadKind, out this.batchBoundary);
+                this.format = MediaTypeUtils.GetFormatFromContentType(contentType, new ODataPayloadKind[] { this.writerPayloadKind }, this.mediaTypeResolver, out this.mediaType, out this.encoding, out computedPayloadKind);
                 Debug.Assert(this.writerPayloadKind == computedPayloadKind, "The payload kinds must always match.");
 
                 if (this.settings.HasJsonPaddingFunction())
@@ -835,31 +830,7 @@ namespace Microsoft.OData
                 // we fall back to a default (of null accept headers).
                 this.format = MediaTypeUtils.GetContentTypeFromSettings(this.settings, this.writerPayloadKind, this.mediaTypeResolver, out this.mediaType, out this.encoding);
 
-                if (this.writerPayloadKind == ODataPayloadKind.Batch)
-                {
-                    // Note that this serves as verification only for now, since we only support a single content type and format for $batch payloads.
-                    Debug.Assert(this.format == ODataFormat.Batch, "$batch should only support batch format since it's format independent.");
-                    Debug.Assert(this.mediaType.FullTypeName == MimeConstants.MimeMultipartMixed, "$batch content type is currently only supported to be multipart/mixed.");
-
-                    //// TODO: What about the encoding - should we verify that it's 7bit US-ASCII only?
-
-                    this.batchBoundary = ODataMultipartMixedBatchWriterUtils.CreateBatchBoundary(this.writingResponse);
-
-                    // Set the content type header here since all headers have to be set before getting the stream
-                    // Note that the mediaType may have additional parameters, which we ignore here (intentional as per MIME spec).
-                    // Note that we always generate a new boundary string here, even if the accept header contained one.
-                    // We need the boundary to be as unique as possible to avoid possible collision with content of the batch operation payload.
-                    // Our boundary string are generated to fulfill this requirement, client specified ones might not which might lead to wrong responses
-                    // and at least in theory security issues.
-                    contentType = ODataMultipartMixedBatchWriterUtils.CreateMultipartMixedContentType(this.batchBoundary);
-                }
-                else
-                {
-                    this.batchBoundary = null;
-
-                    // Compute the content type (incl. charset) and set the Content-Type header on the response message
-                    contentType = HttpUtils.BuildContentType(this.mediaType, this.encoding);
-                }
+                contentType = format.GetContentType(this.mediaType, this.encoding, this.writingResponse);
 
                 if (this.settings.HasJsonPaddingFunction())
                 {

--- a/src/Microsoft.OData.Core/ODataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataOutputContext.cs
@@ -515,14 +515,13 @@ namespace Microsoft.OData
         /// <summary>
         /// Creates an <see cref="ODataBatchWriter" /> to write a batch of requests or responses.
         /// </summary>
-        /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
         /// <returns>The created batch writer.</returns>
         /// <remarks>We don't plan to make this public!</remarks>
         /// <remarks>
         /// The write must flush the output when it's finished (inside the last Write call).
         /// Since we don't want to support batch format extensibility (at least not yet) this method should remain internal.
         /// </remarks>
-        internal virtual ODataBatchWriter CreateODataBatchWriter(string batchBoundary)
+        internal virtual ODataBatchWriter CreateODataBatchWriter()
         {
             throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.Batch);
         }
@@ -531,14 +530,13 @@ namespace Microsoft.OData
         /// <summary>
         /// Asynchronously creates an <see cref="ODataBatchWriter" /> to write a batch of requests or responses.
         /// </summary>
-        /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
         /// <returns>A running task for the created batch writer.</returns>
         /// <remarks>We don't plan to make this public!</remarks>
         /// <remarks>
         /// The write must flush the output when it's finished (inside the last Write call).
         /// Since we don't want to support batch format extensibility (at least not yet) this method should remain internal.
         /// </remarks>
-        internal virtual Task<ODataBatchWriter> CreateODataBatchWriterAsync(string batchBoundary)
+        internal virtual Task<ODataBatchWriter> CreateODataBatchWriterAsync()
         {
             throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.Batch);
         }

--- a/src/Microsoft.OData.Core/ODataRawInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawInputContext.cs
@@ -19,19 +19,76 @@ namespace Microsoft.OData
     using Microsoft.OData.MultipartMixed;
     #endregion Namespaces
 
+    // TODO: put this in a separate file
+
+    /// <summary>
+    /// Implementation of the OData input for MultipartMixed Batch.
+    /// </summary>
+    internal sealed class ODataMultipartMixedBatchInputContext : ODataRawInputContext
+    {
+        /// <summary>The boundary for writing a batch.</summary>
+        private string batchBoundary;
+
+        /// <summary>Constructor.</summary>
+        /// <param name="format">The format for this input context.</param>
+        /// <param name="messageInfo">The context information for the message.</param>
+        /// <param name="messageReaderSettings">Configuration settings of the OData reader.</param>
+        public ODataMultipartMixedBatchInputContext(
+        ODataFormat format,
+        ODataMessageInfo messageInfo,
+        ODataMessageReaderSettings messageReaderSettings)
+            : base(format, messageInfo, messageReaderSettings)
+        {
+            Debug.Assert(messageInfo.MessageStream != null, "messageInfo.MessageStream != null");
+            Debug.Assert(messageInfo.MediaType != null, "Media type should have been set in messageInfo prior to creating Raw Input Context for Batch");
+            this.batchBoundary = ODataMultipartMixedBatchWriterUtils.GetBatchBoundaryFromMediaType(messageInfo.MediaType);
+        }
+
+        /// <summary>
+        /// Create a <see cref="ODataBatchReader"/>.
+        /// </summary>
+        /// <returns>The newly created <see cref="ODataCollectionReader"/>.</returns>
+        internal override ODataBatchReader CreateBatchReader()
+        {
+            return this.CreateBatchReaderImplementation(/*synchronous*/ true);
+        }
+
+#if PORTABLELIB
+        /// <summary>
+        /// Asynchronously create a <see cref="ODataBatchReader"/>.
+        /// </summary>
+        /// <returns>Task which when completed returns the newly created <see cref="ODataCollectionReader"/>.</returns>
+        internal override Task<ODataBatchReader> CreateBatchReaderAsync()
+        {
+            // Note that the reading is actually synchronous since we buffer the entire input when getting the stream from the message.
+            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateBatchReaderImplementation(/*synchronous*/ false));
+        }
+#endif
+
+        /// <summary>
+        /// Create a <see cref="ODataBatchReader"/>.
+        /// </summary>
+        /// <param name="synchronous">If the reader should be created for synchronous or asynchronous API.</param>
+        /// <returns>The newly created <see cref="ODataCollectionReader"/>.</returns>
+        private ODataBatchReader CreateBatchReaderImplementation(bool synchronous)
+        {
+            return new ODataMultipartMixedBatchReader(this, this.batchBoundary, this.Encoding, synchronous);
+        }
+    }
+
     /// <summary>
     /// Implementation of the OData input for RAW OData format (raw value and batch).
     /// </summary>
-    internal sealed class ODataRawInputContext : ODataInputContext
+    internal class ODataRawInputContext : ODataInputContext
     {
+        /// <summary>The encoding to use to read from the batch stream.</summary>
+        protected readonly Encoding Encoding;
+
         /// <summary>Use a buffer size of 4k that is read from the stream at a time.</summary>
         private const int BufferSize = 4096;
 
         /// <summary>The <see cref="ODataPayloadKind"/> to read.</summary>
         private readonly ODataPayloadKind readerPayloadKind;
-
-        /// <summary>The encoding to use to read from the batch stream.</summary>
-        private readonly Encoding encoding;
 
         /// <summary>The input stream to read the data from.</summary>
         private Stream stream;
@@ -55,7 +112,7 @@ namespace Microsoft.OData
             try
             {
                 this.stream = messageInfo.MessageStream;
-                this.encoding = messageInfo.Encoding;
+                this.Encoding = messageInfo.Encoding;
                 this.readerPayloadKind = messageInfo.PayloadKind;
             }
             catch (Exception e)
@@ -99,29 +156,6 @@ namespace Microsoft.OData
         {
             // Note that the reading is actually synchronous since we buffer the entire input when getting the stream from the message.
             return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateAsynchronousReaderImplementation());
-        }
-#endif
-
-        /// <summary>
-        /// Create a <see cref="ODataBatchReader"/>.
-        /// </summary>
-        /// <param name="batchBoundary">The batch boundary to use.</param>
-        /// <returns>The newly created <see cref="ODataCollectionReader"/>.</returns>
-        internal override ODataBatchReader CreateBatchReader(string batchBoundary)
-        {
-            return this.CreateBatchReaderImplementation(batchBoundary, /*synchronous*/ true);
-        }
-
-#if PORTABLELIB
-        /// <summary>
-        /// Asynchronously create a <see cref="ODataBatchReader"/>.
-        /// </summary>
-        /// <param name="batchBoundary">The batch boundary to use.</param>
-        /// <returns>Task which when completed returns the newly created <see cref="ODataCollectionReader"/>.</returns>
-        internal override Task<ODataBatchReader> CreateBatchReaderAsync(string batchBoundary)
-        {
-            // Note that the reading is actually synchronous since we buffer the entire input when getting the stream from the message.
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateBatchReaderImplementation(batchBoundary, /*synchronous*/ false));
         }
 #endif
 
@@ -183,18 +217,7 @@ namespace Microsoft.OData
         /// <returns>The newly created <see cref="ODataAsynchronousReader"/>.</returns>
         private ODataAsynchronousReader CreateAsynchronousReaderImplementation()
         {
-            return new ODataAsynchronousReader(this, this.encoding);
-        }
-
-        /// <summary>
-        /// Create a <see cref="ODataBatchReader"/>.
-        /// </summary>
-        /// <param name="batchBoundary">The batch boundary to use.</param>
-        /// <param name="synchronous">If the reader should be created for synchronous or asynchronous API.</param>
-        /// <returns>The newly created <see cref="ODataCollectionReader"/>.</returns>
-        private ODataBatchReader CreateBatchReaderImplementation(string batchBoundary, bool synchronous)
-        {
-            return new ODataMultipartMixedBatchReader(this, batchBoundary, this.encoding, synchronous);
+            return new ODataAsynchronousReader(this, this.Encoding);
         }
 
         /// <summary>
@@ -229,7 +252,7 @@ namespace Microsoft.OData
             else
             {
                 Debug.Assert(this.textReader == null, "this.textReader == null");
-                this.textReader = this.encoding == null ? new StreamReader(this.stream) : new StreamReader(this.stream, this.encoding);
+                this.textReader = this.Encoding == null ? new StreamReader(this.stream) : new StreamReader(this.stream, this.Encoding);
                 return this.ReadRawValue(expectedPrimitiveTypeReference);
             }
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/MediaTypeUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/MediaTypeUtilsTests.cs
@@ -350,8 +350,7 @@ namespace Microsoft.OData.Tests
             ODataMediaType mediaType;
             Encoding encoding;
             ODataPayloadKind payloadKind;
-            string batchBoundary;
-            var format = MediaTypeUtils.GetFormatFromContentType(contentType, new[] { ODataPayloadKind.Resource }, resolver ?? ODataMediaTypeResolver.GetMediaTypeResolver(null), out mediaType, out encoding, out payloadKind, out batchBoundary);
+            var format = MediaTypeUtils.GetFormatFromContentType(contentType, new[] { ODataPayloadKind.Resource }, resolver ?? ODataMediaTypeResolver.GetMediaTypeResolver(null), out mediaType, out encoding, out payloadKind);
             mediaType.Should().NotBeNull();
             format.Should().NotBeNull();
             return new TestMediaTypeWithFormat { MediaType = mediaType, Format = format };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataBatchReaderStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataBatchReaderStreamTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using Microsoft.OData.MultipartMixed;
 using Xunit;
 using ErrorStrings = Microsoft.OData.Strings;
+using System.Collections.Generic;
 
 namespace Microsoft.OData.Tests
 {
@@ -64,19 +65,20 @@ Second line";
 
         private static ODataMultipartMixedBatchReaderStream CreateBatchReaderStream(string inputString)
         {
+            string boundary = "batch_862fb28e-dc50-4af1-aad5-9608647761d1";
             var messageInfo = new ODataMessageInfo
             {
                 Encoding = Encoding.UTF8,
                 IsResponse = false,
                 IsAsync = false,
-                PayloadKind = ODataPayloadKind.Batch,
-                MessageStream = new MemoryStream(Encoding.UTF8.GetBytes(inputString))
+                MessageStream = new MemoryStream(Encoding.UTF8.GetBytes(inputString)),
+                MediaType = new ODataMediaType(MimeConstants.MimeMultipartType, MimeConstants.MimeMixedSubType, new KeyValuePair<string,string>(ODataConstants.HttpMultipartBoundary, boundary))
             };
-            var inputContext = new ODataRawInputContext(
+            var inputContext = new ODataMultipartMixedBatchInputContext(
                 ODataFormat.Batch,
                 messageInfo,
                 new ODataMessageReaderSettings());
-            var batchStream = new ODataMultipartMixedBatchReaderStream(inputContext, "batch_862fb28e-dc50-4af1-aad5-9608647761d1", Encoding.UTF8);
+            var batchStream = new ODataMultipartMixedBatchReaderStream(inputContext, boundary, Encoding.UTF8);
             return batchStream;
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMediaTypeResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMediaTypeResolverTests.cs
@@ -176,15 +176,13 @@ namespace Microsoft.OData.Tests
                 ODataMediaType mediaType;
                 Encoding encoding;
                 ODataPayloadKind selectedPayloadKind;
-                string batchBoundary;
-                ODataFormat actual = MediaTypeUtils.GetFormatFromContentType(contentType, new[] { payloadKind }, resolver, out mediaType, out encoding, out selectedPayloadKind, out batchBoundary);
+                ODataFormat actual = MediaTypeUtils.GetFormatFromContentType(contentType, new[] { payloadKind }, resolver, out mediaType, out encoding, out selectedPayloadKind);
 
                 Console.WriteLine(payloadKind);
                 actual.ShouldBeEquivalentTo(MyFormat.Instance);
                 mediaType.ShouldBeEquivalentTo(expectedMediaType);
                 encoding.ShouldBeEquivalentTo(payloadKind == ODataPayloadKind.BinaryValue ? null : Encoding.UTF8);
                 selectedPayloadKind.ShouldBeEquivalentTo(payloadKind);
-                batchBoundary.ShouldBeEquivalentTo(expectedBoundary);
             }
         }
 


### PR DESCRIPTION
…mixed data types:

1) Moves logic for determining batchBoundary from MediaTypeUtils to MultipartMixedBatchWriterUtils.
   a.	Adds virtual method to Format base class for determining content type with default implementation
   b.	For ODataBatchFormat, override to adds the boundary
   c.	Calls method from ODataMessageWriter
2) Removes batchBoundary from calls to CreateBatchReader/CreateBatchWriter
   a.	Adds private boundary to raw input/output context
   b.	Sets from messageInfo.Mediatype when context is created
   c.	Passes in to multipartmixed reader/writer constructor from context
3)	Remove MediaTypeUtils.GetFormatForContentType overload that returns batchBoundary
   a.	Makes existing private method that doesn't return batchBoundary internal, and has callers call that instead.
   b.	In MultipartMixedBatchReaderStream.DetermineChangesetBoundaryAndEncoding(), gets from mediatype
4) Factors Batch-specific behavior into subclass of ODataRawInputContex/ODataRawOutputContext (note: derived classes should be moved to their own files)
   =>Consider whether ODataMultipartMixedBatchInput/OutputContext should derive from ODataRawInput/OutputContext, they should share a base class, or be completely independent

### Issues
*This pull request fixes issue #xxx.*  

### Description
*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
